### PR TITLE
Fix in-tree eclipse project build

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,6 +1,6 @@
 [alias]
-  ci = //:ci
-  plugin = //:ci
+  ci = //:gerrit-ci-plugin
+  plugin = //:gerrit-ci-plugin
 
 [java]
   src_roots = java, resources
@@ -11,4 +11,3 @@
 [cache]
   mode = dir
   dir = buck-out/cache
-

--- a/BUCK
+++ b/BUCK
@@ -1,7 +1,7 @@
 include_defs('//bucklets/gerrit_plugin.bucklet')
 
 gerrit_plugin(
-  name = 'ci',
+  name = 'gerrit-ci-plugin',
   srcs = glob(['src/main/java/**/*.java']),
   resources = glob(['src/main/**/*']),
   manifest_entries = [
@@ -21,16 +21,16 @@ gerrit_plugin(
 java_test(
   name = 'ci_tests',
   srcs = glob(['src/test/java/**/*IT.java']),
-  labels = ['ci-plugin'],
-  source_under_test = [':ci__plugin'],
+  labels = ['gerrit-ci-plugin'],
+  source_under_test = [':gerrit-ci-plugin__plugin'],
   deps = GERRIT_PLUGIN_API + GERRIT_TESTS + [
-    ':ci__plugin',
+    ':gerrit-ci-plugin__plugin',
   ],
 )
 
 java_library(
   name = 'classpath',
   deps = GERRIT_PLUGIN_API + GERRIT_TESTS + [
-    ':ci__plugin'
+    ':gerrit-ci-plugin__plugin'
   ],
 )


### PR DESCRIPTION
I get the following error when attempting to build the eclipse
project with gerrit-ci-plugin in tree:

~/work-gerrit$ ./tools/eclipse/project.py
Not using buckd because watchman isn't installed.
[-] PARSING BUCK FILES...FINISHED 1.5s [100%]
BUILD FAILED: Couldn't get dependency
'//plugins/gerrit-ci-plugin:gerrit-ci-plugin__plugin' of target
'//tools/eclipse:classpath':
No rule found when resolving target
//plugins/gerrit-ci-plugin:gerrit-ci-plugin__plugin in build file
//plugins/gerrit-ci-plugin/BUCK
Defined in file: /Users/zaro0508/work-gerrit/plugins/gerrit-ci-plugin/BUCK

Changing the plugin name to match the directory fixed this issue.
